### PR TITLE
change deque argument to maxlen

### DIFF
--- a/pgop/util.py
+++ b/pgop/util.py
@@ -84,7 +84,7 @@ class _Cache:
         """
         self._data = {}
         self._key_counts = collections.Counter()
-        self._recent_keys = collections.deque(max_size=keep_n_most_recent)
+        self._recent_keys = collections.deque(maxlen=keep_n_most_recent)
         self.max_size = max_size
 
     def __contains__(self, key):


### PR DESCRIPTION
Argument used in deque is max_size, but according to https://docs.python.org/3.8/library/collections.html#collections.deque
it should be maxlen.