### PR TITLE
Update freud dependency for 3.0 and fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,15 @@ classifiers = [
         "Programming Language :: Python :: 3.11",
     ]
 dependencies = [
-    "coxeter",
     "numpy",  # basic numerical Python
-    "freud-analysis",  # for neighbor finding
+    "freud-analysis>=3.0.0",  # for neighbor finding
+    "scipy",
+    "rowan",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "coxeter",
     "h5py",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,13 @@ def get_shape_sys_nlist(vertices):
     # vertices = shape.vertices
     query_point_indices = np.zeros(len(vertices), dtype=int)
     point_indices = np.arange(0, len(vertices), dtype=int)
+    # compute bond vectors between from query points to points
+    vectors = vertices[point_indices] - vertices[query_point_indices]
     distances = np.linalg.norm(vertices, axis=1)
     return (
         (freud.Box.cube(2.1 * np.max(distances)), vertices),
         freud.locality.NeighborList.from_arrays(
-            1, len(vertices), query_point_indices, point_indices, distances
+            1, len(vertices), query_point_indices, point_indices, vectors
         ),
     )
 


### PR DESCRIPTION
This PR adds support for freud 3.0. Due to API changes the dependencies have to be update to require freud>=3.0 . Also, tests must be updated for this as well.