### PR TITLE
Add descriptive error when passing invalid mode to PGOP

### DIFF
--- a/pgop/pgop.py
+++ b/pgop/pgop.py
@@ -320,6 +320,9 @@ class PGOP:
             m_mode = 0
         elif mode == "boo":
             m_mode = 1
+        else:
+            msg = f"Mode '{mode}' is not valid " "(valid params: {'full', 'boo'})"
+            raise ValueError(msg)
         self._mode = mode
         self._cpp = pgop._pgop.PGOP(
             matrices,


### PR DESCRIPTION
Previously, passing an invalid mode would lead to the following error:

```
    self._cpp = pgop._pgop.PGOP(matrices, optimizer._cpp, m_mode)
                                                          ^^^^^^
UnboundLocalError: cannot access local variable 'm_mode' where it is not associated with a value
```

Now, a ValueError with debug information is printed instead.