### PR TITLE
Fix bug in Bhattacharyya metric

### DIFF
--- a/src/PGOP.cc
+++ b/src/PGOP.cc
@@ -222,7 +222,7 @@ inline double compute_Bhattacharyya_coefficient_gaussian(const data::Vec3& posit
     auto sigmas_squared_summed = sigma * sigma + sigma_symmetrized * sigma_symmetrized;
     // 2. compute the gaussian overlap between the two points. Bhattacharyya coefficient
     //    is used.
-    double lead_term = (2 * sigma * sigma_symmetrized / sigmas_squared_summed):
+    double lead_term = (2 * sigma * sigma_symmetrized / sigmas_squared_summed);
     return lead_term * std::sqrt(lead_term)
            * std::exp(-r_pos.dot(r_pos) / (4 * sigmas_squared_summed));
 }


### PR DESCRIPTION
> NOTE: the previous implementation was actually incorrect, as we took the lead term to power `int 3/2=1` rather than 1.5 as expected. This new implementation is ~10% slower, but is correct and 4x faster than using powf correctly
<!-- Provide a general summary of your changes in the Title above. -->

This is the first of a few small performance improvements, here I swapped a powf for x sqrt(x) in the distance metric. I'm doing some testing for optimization performance and caught that we could possibly improve this.

### Other changes (TODO)

Save (coordination number) of EXP evaluations per particle
```c++
// ...
// compute log Bhattacharyya, then only exponentiate when max is found
    return r_pos.dot(r_pos) / (4.0 * sigmas_squared_summed);

```

### Notes

Hillinger distance requires a minor refactor as it is a distance rather than an overlap (need to minimize, not maximize. 

Microbenchmark:

```c++
#include <chrono>
#include <cmath>
#include <iostream>
#include <numeric>
#include <vector>

using namespace std;
using namespace std::chrono;

int main()
{
    volatile double sink = 0.0;
    const long long num_iterations = 1000000;
    vector<double> data(1000);
    iota(data.begin(), data.end(), 1.0);

    auto start_sqrt = high_resolution_clock::now();
    for (long long i = 0; i < num_iterations; ++i) {
        for (const double x : data)
            sink = x * sqrt(x);
    }
    duration<double, milli> dur_sqrt = high_resolution_clock::now() - start_sqrt;
    std::cout << "Method: x * sqrt(x)\nTotal time: " << dur_sqrt.count() << " ms\n\n";

    auto start_pow = high_resolution_clock::now();
    for (long long i = 0; i < num_iterations; ++i) {
        for (const double x : data)
            sink = pow(x, 1.5);
    }
    duration<double, milli> dur_pow = high_resolution_clock::now() - start_pow;
    std::cout << "Method: pow(x, 1.5)\nTotal time: " << dur_pow.count() << " ms\n\n";

    return 0;
}
```
```bash
> g++ -O3 -o bench bench.cpp && ./bench
Method: x * std::sqrt(x)
Total time: 651.973 ms

Method: std::pow(x, 1.5)
Total time: 7536.21 ms

```

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/spatula/blob/main/CONTRIBUTING.rst).
- [ ] I agree with the terms of the [**spatula Contributor Agreement**](https://github.com/glotzerlab/spatula/blob/main/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/spatula/blob/main/AUTHORS.rst) in the pull request source branch.
- [ ] I have updated the [Change log](https://github.com/glotzerlab/spatula/blob/main/changelog.rst).
